### PR TITLE
Increase max time for some response time tests

### DIFF
--- a/demo-api/scanapi-report.html
+++ b/demo-api/scanapi-report.html
@@ -409,7 +409,7 @@
             
             <h1 class="title__name">Report generated for <span class="title__project">Snippets API</span></h1>
             
-            <p class="title__overview">Generated at: 2021-06-11 16:05:58</p>
+            <p class="title__overview">Generated at: 2021-08-02 16:42:18</p>
         </header>
 
         <!-- summary_box -->
@@ -459,7 +459,7 @@
                                     User-Agent
                                 </td>
                                 <td>
-                                    python-requests/2.24.0
+                                    python-requests/2.26.0
                                 </td>
                             </tr>
                             <tr>
@@ -503,7 +503,7 @@
 
                     <details>
                         <summary>cURL</summary>
-                        <pre>curl -X GET -H "User-Agent: python-requests/2.24.0" -H "Accept-Encoding: gzip, deflate" -H "Accept: */*" -H "Connection: keep-alive" -H "Content-Type: application/json" -d 'None' http://demo.scanapi.dev/api/v1/health/ --compressed</pre>
+                        <pre>curl -X GET -H &#34;User-Agent: python-requests/2.26.0&#34; -H &#34;Accept-Encoding: gzip, deflate&#34; -H &#34;Accept: */*&#34; -H &#34;Connection: keep-alive&#34; -H &#34;Content-Type: application/json&#34; -d &#39;None&#39; http://demo.scanapi.dev/api/v1/health/ --compressed</pre>
                         <button class="copy__snippet">&#10063;</button>
                     </details>
                 </section>
@@ -525,7 +525,7 @@
                                     response time
                                 </td>
                                 <td>
-                                    0.83217 s
+                                    0.550603 s
                                 </td>
                             </tr>
                             <tr>
@@ -559,7 +559,7 @@
                                         Date
                                     </td>
                                     <td>
-                                        Fri, 11 Jun 2021 19:05:59 GMT
+                                        Mon, 02 Aug 2021 19:42:20 GMT
                                     </td>
                                 </tr>
                             </tbody>
@@ -596,7 +596,7 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        Vary
+                                        vary
                                     </td>
                                     <td>
                                         Accept, Cookie
@@ -606,7 +606,7 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        Allow
+                                        allow
                                     </td>
                                     <td>
                                         GET, HEAD, OPTIONS
@@ -616,7 +616,7 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        X-Frame-Options
+                                        x-frame-options
                                     </td>
                                     <td>
                                         DENY
@@ -626,7 +626,7 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        X-Content-Type-Options
+                                        x-content-type-options
                                     </td>
                                     <td>
                                         nosniff
@@ -636,7 +636,7 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        Referrer-Policy
+                                        referrer-policy
                                     </td>
                                     <td>
                                         same-origin
@@ -646,7 +646,7 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        Via
+                                        via
                                     </td>
                                     <td>
                                         1.1 vegur
@@ -666,10 +666,10 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        cf-request-id
+                                        Last-Modified
                                     </td>
                                     <td>
-                                        0a9e10923f0000589e5d1f9000000001
+                                        Mon, 02 Aug 2021 19:42:20 GMT
                                     </td>
                                 </tr>
                             </tbody>
@@ -679,7 +679,7 @@
                                         Report-To
                                     </td>
                                     <td>
-                                        {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v2?s=YYXym%2Fx%2FGLgILDM4BWCunlDzN2BrisXziA8h6kCn6GlsjtLvM4japYTPAaodZtcvem4O2cx3MuBVd59naCyGR2l%2F4je%2FioFmLnRlS9gXcR7ASlbW%2BEPN1wqSU0gUFXW1oeakuUqyQYRiAQ%3D%3D"}],"group":"cf-nel","max_age":604800}
+                                        {&#34;endpoints&#34;:[{&#34;url&#34;:&#34;https:\/\/a.nel.cloudflare.com\/report\/v3?s=QR55%2BTgAmqd8ycvAbCroESNBCfdlYdhiUjd%2FXyAkqblK%2FmXTEYck6zvJS1%2Bdp5udaK8C6%2B1B80VQAAXMhtLDNRB9%2Fg1iCOk6P8hineysoc3t2b%2BNi%2BOHyLFvj%2F3HX8FuRt8T6EDtAjWOBZHQ6gjP&#34;}],&#34;group&#34;:&#34;cf-nel&#34;,&#34;max_age&#34;:604800}
                                     </td>
                                 </tr>
                             </tbody>
@@ -689,7 +689,7 @@
                                         NEL
                                     </td>
                                     <td>
-                                        {"report_to":"cf-nel","max_age":604800}
+                                        {&#34;report_to&#34;:&#34;cf-nel&#34;,&#34;max_age&#34;:604800}
                                     </td>
                                 </tr>
                             </tbody>
@@ -709,7 +709,7 @@
                                         CF-RAY
                                     </td>
                                     <td>
-                                        65dd1d306faf589e-POA
+                                        6789c9edda595898-POA
                                     </td>
                                 </tr>
                             </tbody>
@@ -719,7 +719,7 @@
                                         alt-svc
                                     </td>
                                     <td>
-                                        h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443"; ma=86400
+                                        h3-27=&#34;:443&#34;; ma=86400, h3-28=&#34;:443&#34;; ma=86400, h3-29=&#34;:443&#34;; ma=86400, h3=&#34;:443&#34;; ma=86400
                                     </td>
                                 </tr>
                             </tbody>
@@ -730,7 +730,7 @@
                     <details>
                         <summary>Content</summary>
                         <p class="json-body">
-                             "OK!" 
+                             &#34;OK!&#34; 
                         </p>
                         <button class="copy__snippet">&#10063;</button>
                     </details>
@@ -816,7 +816,7 @@
                                     User-Agent
                                 </td>
                                 <td>
-                                    python-requests/2.24.0
+                                    python-requests/2.26.0
                                 </td>
                             </tr>
                             <tr>
@@ -867,14 +867,14 @@
                     
                     <details>
                         <summary>Body</summary>
-                        <p class="json-body">{"username": "guest", "password": "SENSITIVE_INFORMATION"}</p>
+                        <p class="json-body">{&#34;username&#34;: &#34;guest&#34;, &#34;password&#34;: &#34;SENSITIVE_INFORMATION&#34;}</p>
                         <button class="copy__snippet">&#10063;</button>
                     </details>
                     
 
                     <details>
                         <summary>cURL</summary>
-                        <pre>curl -X POST -H "User-Agent: python-requests/2.24.0" -H "Accept-Encoding: gzip, deflate" -H "Accept: */*" -H "Connection: keep-alive" -H "Content-Type: application/json" -H "Content-Length: 47" -d '{"username": "guest", "password": "SENSITIVE_INFORMATION"}' http://demo.scanapi.dev/api/v1/rest-auth/login/ --compressed</pre>
+                        <pre>curl -X POST -H &#34;User-Agent: python-requests/2.26.0&#34; -H &#34;Accept-Encoding: gzip, deflate&#34; -H &#34;Accept: */*&#34; -H &#34;Connection: keep-alive&#34; -H &#34;Content-Type: application/json&#34; -H &#34;Content-Length: 47&#34; -d &#39;{&#34;username&#34;: &#34;guest&#34;, &#34;password&#34;: &#34;SENSITIVE_INFORMATION&#34;}&#39; http://demo.scanapi.dev/api/v1/rest-auth/login/ --compressed</pre>
                         <button class="copy__snippet">&#10063;</button>
                     </details>
                 </section>
@@ -896,7 +896,7 @@
                                     response time
                                 </td>
                                 <td>
-                                    0.884435 s
+                                    0.813175 s
                                 </td>
                             </tr>
                             <tr>
@@ -930,7 +930,7 @@
                                         Date
                                     </td>
                                     <td>
-                                        Fri, 11 Jun 2021 19:06:00 GMT
+                                        Mon, 02 Aug 2021 19:42:21 GMT
                                     </td>
                                 </tr>
                             </tbody>
@@ -1020,7 +1020,7 @@
                                         Set-Cookie
                                     </td>
                                     <td>
-                                        csrftoken=YmGuq23VN8LPJwTA3AHumMTY4O5SGoFTKg3OkGGMFaU9mTbrb6agYGNlc18hjNFI; expires=Fri, 10 Jun 2022 19:06:00 GMT; Max-Age=31449600; Path=/; SameSite=Lax, sessionid=cvsvetg0gqphffzby4xaat2y64yjzjtb; expires=Fri, 25 Jun 2021 19:06:00 GMT; HttpOnly; Max-Age=1209600; Path=/; SameSite=Lax
+                                        csrftoken=sZ7PurCZqMnXEL4dKwungZQowtPHRW2fkdzmkGNA40Flznv8RTTNA8tW9nWgMRUv; expires=Mon, 01 Aug 2022 19:42:20 GMT; Max-Age=31449600; Path=/; SameSite=Lax, sessionid=lnpv9jg4vf4d9htr72p326t4yxoqc2zo; expires=Mon, 16 Aug 2021 19:42:20 GMT; HttpOnly; Max-Age=1209600; Path=/; SameSite=Lax
                                     </td>
                                 </tr>
                             </tbody>
@@ -1047,10 +1047,10 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        cf-request-id
+                                        Last-Modified
                                     </td>
                                     <td>
-                                        0a9e1094bf0000589e99033000000001
+                                        Mon, 02 Aug 2021 19:42:21 GMT
                                     </td>
                                 </tr>
                             </tbody>
@@ -1060,7 +1060,7 @@
                                         Report-To
                                     </td>
                                     <td>
-                                        {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v2?s=iiC%2BG49T%2Bozx16aUTb8GWPayA%2FtGH9zWdraejVJCfivBCWHqPpcyPXsQSoUepgIkRzB3pvSswoOtwLuQ6wwu20INadWJr5zDiANfUJJPG5k%2FjQnpxQ197NVTfj2G8QLD5pNnIZ8LYBpbHQ%3D%3D"}],"group":"cf-nel","max_age":604800}
+                                        {&#34;endpoints&#34;:[{&#34;url&#34;:&#34;https:\/\/a.nel.cloudflare.com\/report\/v3?s=%2BwB8POE1D%2Brr0f03O0f%2Bl%2BZel7JYdo2ffIMA23SnHs4imb2iKuadQfOvwaZ3eL1JUmNJV%2BwD8hO45nHdLK5qTzdwzuuCNwNiK%2BscE8CGskhPpsOt4Av6Ku3ofganm98hun1mVMuvpThNgsXL6rRZ&#34;}],&#34;group&#34;:&#34;cf-nel&#34;,&#34;max_age&#34;:604800}
                                     </td>
                                 </tr>
                             </tbody>
@@ -1070,7 +1070,7 @@
                                         NEL
                                     </td>
                                     <td>
-                                        {"report_to":"cf-nel","max_age":604800}
+                                        {&#34;report_to&#34;:&#34;cf-nel&#34;,&#34;max_age&#34;:604800}
                                     </td>
                                 </tr>
                             </tbody>
@@ -1090,7 +1090,7 @@
                                         CF-RAY
                                     </td>
                                     <td>
-                                        65dd1d346a25589e-POA
+                                        6789c9f159d658aa-POA
                                     </td>
                                 </tr>
                             </tbody>
@@ -1110,7 +1110,7 @@
                                         alt-svc
                                     </td>
                                     <td>
-                                        h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443"; ma=86400
+                                        h3-27=&#34;:443&#34;; ma=86400, h3-28=&#34;:443&#34;; ma=86400, h3-29=&#34;:443&#34;; ma=86400, h3=&#34;:443&#34;; ma=86400
                                     </td>
                                 </tr>
                             </tbody>
@@ -1121,7 +1121,7 @@
                     <details>
                         <summary>Content</summary>
                         <p class="json-body">
-                             {"key": "SENSITIVE_INFORMATION"} 
+                             {&#34;key&#34;: &#34;SENSITIVE_INFORMATION&#34;} 
                         </p>
                         <button class="copy__snippet">&#10063;</button>
                     </details>
@@ -1166,7 +1166,7 @@
                         </div>
                         <div class="endpoint__testcaseLabel">
                             <span>
-                                snippets-api::get_token::response_time_is_under_a_second
+                                snippets-api::get_token::response_time_is_under_two_seconds
                             </span>
                             
                             
@@ -1221,7 +1221,7 @@
                                     User-Agent
                                 </td>
                                 <td>
-                                    python-requests/2.24.0
+                                    python-requests/2.26.0
                                 </td>
                             </tr>
                             <tr>
@@ -1280,14 +1280,14 @@
                     
                     <details>
                         <summary>Body</summary>
-                        <p class="json-body">{"title": "Hello World", "code": "print('hello world')", "style": "xcode", "language": "python"}</p>
+                        <p class="json-body">{&#34;title&#34;: &#34;Hello World&#34;, &#34;code&#34;: &#34;print(&#39;hello world&#39;)&#34;, &#34;style&#34;: &#34;xcode&#34;, &#34;language&#34;: &#34;python&#34;}</p>
                         <button class="copy__snippet">&#10063;</button>
                     </details>
                     
 
                     <details>
                         <summary>cURL</summary>
-                        <pre>curl -X POST -H "User-Agent: python-requests/2.24.0" -H "Accept-Encoding: gzip, deflate" -H "Accept: */*" -H "Connection: keep-alive" -H "Content-Type: application/json" -H "Authorization: SENSITIVE_INFORMATION" -H "Content-Length: 96" -d '{"title": "Hello World", "code": "print('hello world')", "style": "xcode", "language": "python"}' http://demo.scanapi.dev/api/v1/snippets/ --compressed</pre>
+                        <pre>curl -X POST -H &#34;User-Agent: python-requests/2.26.0&#34; -H &#34;Accept-Encoding: gzip, deflate&#34; -H &#34;Accept: */*&#34; -H &#34;Connection: keep-alive&#34; -H &#34;Content-Type: application/json&#34; -H &#34;Authorization: SENSITIVE_INFORMATION&#34; -H &#34;Content-Length: 96&#34; -d &#39;{&#34;title&#34;: &#34;Hello World&#34;, &#34;code&#34;: &#34;print(&#39;hello world&#39;)&#34;, &#34;style&#34;: &#34;xcode&#34;, &#34;language&#34;: &#34;python&#34;}&#39; http://demo.scanapi.dev/api/v1/snippets/ --compressed</pre>
                         <button class="copy__snippet">&#10063;</button>
                     </details>
                 </section>
@@ -1309,7 +1309,7 @@
                                     response time
                                 </td>
                                 <td>
-                                    0.50372 s
+                                    0.501231 s
                                 </td>
                             </tr>
                             <tr>
@@ -1343,7 +1343,7 @@
                                         Date
                                     </td>
                                     <td>
-                                        Fri, 11 Jun 2021 19:06:01 GMT
+                                        Mon, 02 Aug 2021 19:42:21 GMT
                                     </td>
                                 </tr>
                             </tbody>
@@ -1380,17 +1380,17 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        Location
+                                        location
                                     </td>
                                     <td>
-                                        http://demo.scanapi.dev/api/v1/snippets/231/
+                                        http://demo.scanapi.dev/api/v1/snippets/630/
                                     </td>
                                 </tr>
                             </tbody>
                             <tbody>
                                 <tr>
                                     <td>
-                                        Vary
+                                        vary
                                     </td>
                                     <td>
                                         Accept
@@ -1400,7 +1400,7 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        Allow
+                                        allow
                                     </td>
                                     <td>
                                         GET, POST, HEAD, OPTIONS
@@ -1410,7 +1410,7 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        X-Frame-Options
+                                        x-frame-options
                                     </td>
                                     <td>
                                         DENY
@@ -1420,7 +1420,7 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        X-Content-Type-Options
+                                        x-content-type-options
                                     </td>
                                     <td>
                                         nosniff
@@ -1430,7 +1430,7 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        Referrer-Policy
+                                        referrer-policy
                                     </td>
                                     <td>
                                         same-origin
@@ -1440,7 +1440,7 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        Via
+                                        via
                                     </td>
                                     <td>
                                         1.1 vegur
@@ -1460,20 +1460,10 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        cf-request-id
-                                    </td>
-                                    <td>
-                                        0a9e1098380000589f64313000000001
-                                    </td>
-                                </tr>
-                            </tbody>
-                            <tbody>
-                                <tr>
-                                    <td>
                                         Report-To
                                     </td>
                                     <td>
-                                        {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v2?s=C%2Frq2hLdVoCxGMLKau8Yuaei723ocqnLOTspmg%2BWzJjwAPl5uEsJ6ZJMpw8Yu0vM3ZOZm2JtTJGdu49%2FQl4ImgCVP%2BeSBU9RkTuhbDptXp1jQV2XUj45wGbJnFq9EP%2BN%2FnZguPNxnC763w%3D%3D"}],"group":"cf-nel","max_age":604800}
+                                        {&#34;endpoints&#34;:[{&#34;url&#34;:&#34;https:\/\/a.nel.cloudflare.com\/report\/v3?s=ftLeEnPmuLm9xEs9BXvFC6sC5aVjS9syv7F0zJPNuPhT11RmQgVqszBUTJs%2FhRTnLReelSbSIKpgIYlEqQz1TAbeSImL%2FAH1Rr7c%2FKWaZJGIST%2F0YZpqe%2BZp%2BWveJihueOlEnRE8Y7iz7yvzNPV3&#34;}],&#34;group&#34;:&#34;cf-nel&#34;,&#34;max_age&#34;:604800}
                                     </td>
                                 </tr>
                             </tbody>
@@ -1483,7 +1473,7 @@
                                         NEL
                                     </td>
                                     <td>
-                                        {"report_to":"cf-nel","max_age":604800}
+                                        {&#34;report_to&#34;:&#34;cf-nel&#34;,&#34;max_age&#34;:604800}
                                     </td>
                                 </tr>
                             </tbody>
@@ -1503,7 +1493,7 @@
                                         CF-RAY
                                     </td>
                                     <td>
-                                        65dd1d39f966589f-POA
+                                        6789c9f68fc4589e-POA
                                     </td>
                                 </tr>
                             </tbody>
@@ -1513,7 +1503,7 @@
                                         alt-svc
                                     </td>
                                     <td>
-                                        h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443"; ma=86400
+                                        h3-27=&#34;:443&#34;; ma=86400, h3-28=&#34;:443&#34;; ma=86400, h3-29=&#34;:443&#34;; ma=86400, h3=&#34;:443&#34;; ma=86400
                                     </td>
                                 </tr>
                             </tbody>
@@ -1524,7 +1514,7 @@
                     <details>
                         <summary>Content</summary>
                         <p class="json-body">
-                             {"url":"http://demo.scanapi.dev/api/v1/snippets/231/","id":231,"highlight":"http://demo.scanapi.dev/api/v1/snippets/231/highlight/","owner":"guest","title":"Hello World","code":"print('hello world')","linenos":false,"language":"python","style":"xcode"} 
+                             {&#34;url&#34;:&#34;http://demo.scanapi.dev/api/v1/snippets/630/&#34;,&#34;id&#34;:630,&#34;highlight&#34;:&#34;http://demo.scanapi.dev/api/v1/snippets/630/highlight/&#34;,&#34;owner&#34;:&#34;guest&#34;,&#34;title&#34;:&#34;Hello World&#34;,&#34;code&#34;:&#34;print(&#39;hello world&#39;)&#34;,&#34;linenos&#34;:false,&#34;language&#34;:&#34;python&#34;,&#34;style&#34;:&#34;xcode&#34;} 
                         </p>
                         <button class="copy__snippet">&#10063;</button>
                     </details>
@@ -1555,7 +1545,7 @@
                         </div>
                         <div class="endpoint__testcaseLabel">
                             <span>
-                                snippets-api::snippets::create::response_time_is_under_a_second
+                                snippets-api::snippets::create::response_time_is_under_two_seconds
                             </span>
                             
                             
@@ -1701,7 +1691,7 @@
             <label class="endpoint__title" for="chck_4">
                 <span class="endpoint__url">
                     <img data-anchor="endpoint_4" class="copy__link_anchor_url" src="https://scanapi.s3.us-east-2.amazonaws.com/assets/images/icons/link.svg">
-                    <span class="http_method">GET</span> /api/v1/snippets/231/
+                    <span class="http_method">GET</span> /api/v1/snippets/630/
                     <span class="endpoint__request_node_name">details</span>
                 </span>
                 <span class="endpoint__titleInfo">
@@ -1715,7 +1705,7 @@
             <div class="endpoint__content">
                 <section class="endpoint__request">
                     <h3>Request</h3>
-                    <p>Full URL: <a href="http://demo.scanapi.dev/api/v1/snippets/231/"> http://demo.scanapi.dev/api/v1/snippets/231/</a></p>
+                    <p>Full URL: <a href="http://demo.scanapi.dev/api/v1/snippets/630/"> http://demo.scanapi.dev/api/v1/snippets/630/</a></p>
 
                     
                     <table>
@@ -1736,7 +1726,7 @@
                                     User-Agent
                                 </td>
                                 <td>
-                                    python-requests/2.24.0
+                                    python-requests/2.26.0
                                 </td>
                             </tr>
                             <tr>
@@ -1788,7 +1778,7 @@
 
                     <details>
                         <summary>cURL</summary>
-                        <pre>curl -X GET -H "User-Agent: python-requests/2.24.0" -H "Accept-Encoding: gzip, deflate" -H "Accept: */*" -H "Connection: keep-alive" -H "Content-Type: application/json" -H "Authorization: SENSITIVE_INFORMATION" -d 'None' http://demo.scanapi.dev/api/v1/snippets/231/ --compressed</pre>
+                        <pre>curl -X GET -H &#34;User-Agent: python-requests/2.26.0&#34; -H &#34;Accept-Encoding: gzip, deflate&#34; -H &#34;Accept: */*&#34; -H &#34;Connection: keep-alive&#34; -H &#34;Content-Type: application/json&#34; -H &#34;Authorization: SENSITIVE_INFORMATION&#34; -d &#39;None&#39; http://demo.scanapi.dev/api/v1/snippets/630/ --compressed</pre>
                         <button class="copy__snippet">&#10063;</button>
                     </details>
                 </section>
@@ -1810,7 +1800,7 @@
                                     response time
                                 </td>
                                 <td>
-                                    0.402485 s
+                                    0.394897 s
                                 </td>
                             </tr>
                             <tr>
@@ -1844,7 +1834,7 @@
                                         Date
                                     </td>
                                     <td>
-                                        Fri, 11 Jun 2021 19:06:01 GMT
+                                        Mon, 02 Aug 2021 19:42:22 GMT
                                     </td>
                                 </tr>
                             </tbody>
@@ -1881,7 +1871,7 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        Vary
+                                        vary
                                     </td>
                                     <td>
                                         Accept
@@ -1891,7 +1881,7 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        Allow
+                                        allow
                                     </td>
                                     <td>
                                         GET, PUT, PATCH, DELETE, HEAD, OPTIONS
@@ -1901,7 +1891,7 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        X-Frame-Options
+                                        x-frame-options
                                     </td>
                                     <td>
                                         DENY
@@ -1911,7 +1901,7 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        X-Content-Type-Options
+                                        x-content-type-options
                                     </td>
                                     <td>
                                         nosniff
@@ -1921,7 +1911,7 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        Referrer-Policy
+                                        referrer-policy
                                     </td>
                                     <td>
                                         same-origin
@@ -1931,7 +1921,7 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        Via
+                                        via
                                     </td>
                                     <td>
                                         1.1 vegur
@@ -1951,10 +1941,10 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        cf-request-id
+                                        Last-Modified
                                     </td>
                                     <td>
-                                        0a9e109a2e0000589f20830000000001
+                                        Mon, 02 Aug 2021 19:42:22 GMT
                                     </td>
                                 </tr>
                             </tbody>
@@ -1964,7 +1954,7 @@
                                         Report-To
                                     </td>
                                     <td>
-                                        {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v2?s=KEn74KVgdjnSjyFRoUbCigqRYPedJBpW1GOCguWtDZgxctqnPLgfi7Cp7nP8COGX1W0w%2Fd0C61JHLmxYr3ZVv4%2FQqkO%2BhWbIV4BuFo8XFw0N2%2FGUONAquSJIbyuHBc8hGu1x26f5TYctaA%3D%3D"}],"group":"cf-nel","max_age":604800}
+                                        {&#34;endpoints&#34;:[{&#34;url&#34;:&#34;https:\/\/a.nel.cloudflare.com\/report\/v3?s=ZM8liHAa4w5uTbJEhocDrCcQxSgQrpStAwzT9%2FRHCXxxDgQWXOxsjR%2FzVZ%2FFDEHeyVapHvjkC6dhzauA195VErAHrl7FzMjxw7R53EHcefxLi9f%2B22yU0Js25pef94dHz%2BX8qASJhw1zxKqILIwu&#34;}],&#34;group&#34;:&#34;cf-nel&#34;,&#34;max_age&#34;:604800}
                                     </td>
                                 </tr>
                             </tbody>
@@ -1974,7 +1964,7 @@
                                         NEL
                                     </td>
                                     <td>
-                                        {"report_to":"cf-nel","max_age":604800}
+                                        {&#34;report_to&#34;:&#34;cf-nel&#34;,&#34;max_age&#34;:604800}
                                     </td>
                                 </tr>
                             </tbody>
@@ -1994,7 +1984,7 @@
                                         CF-RAY
                                     </td>
                                     <td>
-                                        65dd1d3d1b2c589f-POA
+                                        6789c9f9b981589e-POA
                                     </td>
                                 </tr>
                             </tbody>
@@ -2014,7 +2004,7 @@
                                         alt-svc
                                     </td>
                                     <td>
-                                        h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443"; ma=86400
+                                        h3-27=&#34;:443&#34;; ma=86400, h3-28=&#34;:443&#34;; ma=86400, h3-29=&#34;:443&#34;; ma=86400, h3=&#34;:443&#34;; ma=86400
                                     </td>
                                 </tr>
                             </tbody>
@@ -2025,7 +2015,7 @@
                     <details>
                         <summary>Content</summary>
                         <p class="json-body">
-                             {"url":"http://demo.scanapi.dev/api/v1/snippets/231/","id":231,"highlight":"http://demo.scanapi.dev/api/v1/snippets/231/highlight/","owner":"guest","title":"Hello World","code":"print('hello world')","linenos":false,"language":"python","style":"xcode"} 
+                             {&#34;url&#34;:&#34;http://demo.scanapi.dev/api/v1/snippets/630/&#34;,&#34;id&#34;:630,&#34;highlight&#34;:&#34;http://demo.scanapi.dev/api/v1/snippets/630/highlight/&#34;,&#34;owner&#34;:&#34;guest&#34;,&#34;title&#34;:&#34;Hello World&#34;,&#34;code&#34;:&#34;print(&#39;hello world&#39;)&#34;,&#34;linenos&#34;:false,&#34;language&#34;:&#34;python&#34;,&#34;style&#34;:&#34;xcode&#34;} 
                         </p>
                         <button class="copy__snippet">&#10063;</button>
                     </details>
@@ -2202,7 +2192,7 @@
             <label class="endpoint__title" for="chck_5">
                 <span class="endpoint__url">
                     <img data-anchor="endpoint_5" class="copy__link_anchor_url" src="https://scanapi.s3.us-east-2.amazonaws.com/assets/images/icons/link.svg">
-                    <span class="http_method">PATCH</span> /api/v1/snippets/231/
+                    <span class="http_method">PATCH</span> /api/v1/snippets/630/
                     <span class="endpoint__request_node_name">update_with_patch</span>
                 </span>
                 <span class="endpoint__titleInfo">
@@ -2216,7 +2206,7 @@
             <div class="endpoint__content">
                 <section class="endpoint__request">
                     <h3>Request</h3>
-                    <p>Full URL: <a href="http://demo.scanapi.dev/api/v1/snippets/231/"> http://demo.scanapi.dev/api/v1/snippets/231/</a></p>
+                    <p>Full URL: <a href="http://demo.scanapi.dev/api/v1/snippets/630/"> http://demo.scanapi.dev/api/v1/snippets/630/</a></p>
 
                     
                     <table>
@@ -2237,7 +2227,7 @@
                                     User-Agent
                                 </td>
                                 <td>
-                                    python-requests/2.24.0
+                                    python-requests/2.26.0
                                 </td>
                             </tr>
                             <tr>
@@ -2296,14 +2286,14 @@
                     
                     <details>
                         <summary>Body</summary>
-                        <p class="json-body">{"code": "print('hello, patch')"}</p>
+                        <p class="json-body">{&#34;code&#34;: &#34;print(&#39;hello, patch&#39;)&#34;}</p>
                         <button class="copy__snippet">&#10063;</button>
                     </details>
                     
 
                     <details>
                         <summary>cURL</summary>
-                        <pre>curl -X PATCH -H "User-Agent: python-requests/2.24.0" -H "Accept-Encoding: gzip, deflate" -H "Accept: */*" -H "Connection: keep-alive" -H "Content-Type: application/json" -H "Authorization: SENSITIVE_INFORMATION" -H "Content-Length: 33" -d '{"code": "print('hello, patch')"}' http://demo.scanapi.dev/api/v1/snippets/231/ --compressed</pre>
+                        <pre>curl -X PATCH -H &#34;User-Agent: python-requests/2.26.0&#34; -H &#34;Accept-Encoding: gzip, deflate&#34; -H &#34;Accept: */*&#34; -H &#34;Connection: keep-alive&#34; -H &#34;Content-Type: application/json&#34; -H &#34;Authorization: SENSITIVE_INFORMATION&#34; -H &#34;Content-Length: 33&#34; -d &#39;{&#34;code&#34;: &#34;print(&#39;hello, patch&#39;)&#34;}&#39; http://demo.scanapi.dev/api/v1/snippets/630/ --compressed</pre>
                         <button class="copy__snippet">&#10063;</button>
                     </details>
                 </section>
@@ -2325,7 +2315,7 @@
                                     response time
                                 </td>
                                 <td>
-                                    0.463102 s
+                                    0.473341 s
                                 </td>
                             </tr>
                             <tr>
@@ -2359,7 +2349,7 @@
                                         Date
                                     </td>
                                     <td>
-                                        Fri, 11 Jun 2021 19:06:01 GMT
+                                        Mon, 02 Aug 2021 19:42:22 GMT
                                     </td>
                                 </tr>
                             </tbody>
@@ -2466,10 +2456,10 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        cf-request-id
+                                        Last-Modified
                                     </td>
                                     <td>
-                                        0a9e109bd00000589fff239000000001
+                                        Mon, 02 Aug 2021 19:42:22 GMT
                                     </td>
                                 </tr>
                             </tbody>
@@ -2479,7 +2469,7 @@
                                         Report-To
                                     </td>
                                     <td>
-                                        {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v2?s=V7%2F7K%2FSsuTqto74iicC0GCA7iUYEoBAuNVG%2BwgeX0vS5NiKbc7AmJR%2FfoaBLV%2F6Wjs%2FC0DIFx8Xm8WTyVkRghQibMRVkJoXON7RFeAlz3eV2fa8ZleYYWZaDuPCIxUS9zMj4Jkq%2BPF1H4Q%3D%3D"}],"group":"cf-nel","max_age":604800}
+                                        {&#34;endpoints&#34;:[{&#34;url&#34;:&#34;https:\/\/a.nel.cloudflare.com\/report\/v3?s=BsfDrEJimLd2P0wp1Pjec39WZq2OV%2BlBDJ7%2BNgIw3Hr95fNY2KqoGn1BzYj2fpf5L3uu9CkENKbTFzaKtcm2FDgkV3mrVkV0lxCoClk%2FZBtdVXZmflnG3nyqOdXwXAaE1n5nb8raKmLB9H77D8DA&#34;}],&#34;group&#34;:&#34;cf-nel&#34;,&#34;max_age&#34;:604800}
                                     </td>
                                 </tr>
                             </tbody>
@@ -2489,7 +2479,7 @@
                                         NEL
                                     </td>
                                     <td>
-                                        {"report_to":"cf-nel","max_age":604800}
+                                        {&#34;report_to&#34;:&#34;cf-nel&#34;,&#34;max_age&#34;:604800}
                                     </td>
                                 </tr>
                             </tbody>
@@ -2509,7 +2499,7 @@
                                         CF-RAY
                                     </td>
                                     <td>
-                                        65dd1d3fbcdf589f-POA
+                                        6789c9fc48b158aa-POA
                                     </td>
                                 </tr>
                             </tbody>
@@ -2529,7 +2519,7 @@
                                         alt-svc
                                     </td>
                                     <td>
-                                        h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443"; ma=86400
+                                        h3-27=&#34;:443&#34;; ma=86400, h3-28=&#34;:443&#34;; ma=86400, h3-29=&#34;:443&#34;; ma=86400, h3=&#34;:443&#34;; ma=86400
                                     </td>
                                 </tr>
                             </tbody>
@@ -2540,7 +2530,7 @@
                     <details>
                         <summary>Content</summary>
                         <p class="json-body">
-                             {"url":"http://demo.scanapi.dev/api/v1/snippets/231/","id":231,"highlight":"http://demo.scanapi.dev/api/v1/snippets/231/highlight/","owner":"guest","title":"Hello World","code":"print('hello, patch')","linenos":false,"language":"python","style":"xcode"} 
+                             {&#34;url&#34;:&#34;http://demo.scanapi.dev/api/v1/snippets/630/&#34;,&#34;id&#34;:630,&#34;highlight&#34;:&#34;http://demo.scanapi.dev/api/v1/snippets/630/highlight/&#34;,&#34;owner&#34;:&#34;guest&#34;,&#34;title&#34;:&#34;Hello World&#34;,&#34;code&#34;:&#34;print(&#39;hello, patch&#39;)&#34;,&#34;linenos&#34;:false,&#34;language&#34;:&#34;python&#34;,&#34;style&#34;:&#34;xcode&#34;} 
                         </p>
                         <button class="copy__snippet">&#10063;</button>
                     </details>
@@ -2717,7 +2707,7 @@
             <label class="endpoint__title" for="chck_6">
                 <span class="endpoint__url">
                     <img data-anchor="endpoint_6" class="copy__link_anchor_url" src="https://scanapi.s3.us-east-2.amazonaws.com/assets/images/icons/link.svg">
-                    <span class="http_method">PUT</span> /api/v1/snippets/231/
+                    <span class="http_method">PUT</span> /api/v1/snippets/630/
                     <span class="endpoint__request_node_name">snippet_update_with_put</span>
                 </span>
                 <span class="endpoint__titleInfo">
@@ -2731,7 +2721,7 @@
             <div class="endpoint__content">
                 <section class="endpoint__request">
                     <h3>Request</h3>
-                    <p>Full URL: <a href="http://demo.scanapi.dev/api/v1/snippets/231/"> http://demo.scanapi.dev/api/v1/snippets/231/</a></p>
+                    <p>Full URL: <a href="http://demo.scanapi.dev/api/v1/snippets/630/"> http://demo.scanapi.dev/api/v1/snippets/630/</a></p>
 
                     
                     <table>
@@ -2752,7 +2742,7 @@
                                     User-Agent
                                 </td>
                                 <td>
-                                    python-requests/2.24.0
+                                    python-requests/2.26.0
                                 </td>
                             </tr>
                             <tr>
@@ -2811,14 +2801,14 @@
                     
                     <details>
                         <summary>Body</summary>
-                        <p class="json-body">{"title": "Hello World - Ruby", "code": "puts 'hello world'", "style": "emacs", "language": "ruby"}</p>
+                        <p class="json-body">{&#34;title&#34;: &#34;Hello World - Ruby&#34;, &#34;code&#34;: &#34;puts &#39;hello world&#39;&#34;, &#34;style&#34;: &#34;emacs&#34;, &#34;language&#34;: &#34;ruby&#34;}</p>
                         <button class="copy__snippet">&#10063;</button>
                     </details>
                     
 
                     <details>
                         <summary>cURL</summary>
-                        <pre>curl -X PUT -H "User-Agent: python-requests/2.24.0" -H "Accept-Encoding: gzip, deflate" -H "Accept: */*" -H "Connection: keep-alive" -H "Content-Type: application/json" -H "Authorization: SENSITIVE_INFORMATION" -H "Content-Length: 99" -d '{"title": "Hello World - Ruby", "code": "puts 'hello world'", "style": "emacs", "language": "ruby"}' http://demo.scanapi.dev/api/v1/snippets/231/ --compressed</pre>
+                        <pre>curl -X PUT -H &#34;User-Agent: python-requests/2.26.0&#34; -H &#34;Accept-Encoding: gzip, deflate&#34; -H &#34;Accept: */*&#34; -H &#34;Connection: keep-alive&#34; -H &#34;Content-Type: application/json&#34; -H &#34;Authorization: SENSITIVE_INFORMATION&#34; -H &#34;Content-Length: 99&#34; -d &#39;{&#34;title&#34;: &#34;Hello World - Ruby&#34;, &#34;code&#34;: &#34;puts &#39;hello world&#39;&#34;, &#34;style&#34;: &#34;emacs&#34;, &#34;language&#34;: &#34;ruby&#34;}&#39; http://demo.scanapi.dev/api/v1/snippets/630/ --compressed</pre>
                         <button class="copy__snippet">&#10063;</button>
                     </details>
                 </section>
@@ -2840,7 +2830,7 @@
                                     response time
                                 </td>
                                 <td>
-                                    0.441732 s
+                                    0.725103 s
                                 </td>
                             </tr>
                             <tr>
@@ -2874,7 +2864,7 @@
                                         Date
                                     </td>
                                     <td>
-                                        Fri, 11 Jun 2021 19:06:02 GMT
+                                        Mon, 02 Aug 2021 19:42:23 GMT
                                     </td>
                                 </tr>
                             </tbody>
@@ -2981,10 +2971,10 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        cf-request-id
+                                        Last-Modified
                                     </td>
                                     <td>
-                                        0a9e109da8000058986cba2000000001
+                                        Mon, 02 Aug 2021 19:42:23 GMT
                                     </td>
                                 </tr>
                             </tbody>
@@ -2994,7 +2984,7 @@
                                         Report-To
                                     </td>
                                     <td>
-                                        {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v2?s=KMvKWM3q2a2YOt9fsFV3l2XfgL6JpFlQ0ki%2FcenGfCkqyaGFg8QyjOBQigVU7YGgzTKRmafmlLL1pyBXm%2FTdC22sEK5hhxYKW%2FKqxexITRXZuubAGGlCCvlQyJ%2BhVgIBZZ7n7PQPoJyCng%3D%3D"}],"group":"cf-nel","max_age":604800}
+                                        {&#34;endpoints&#34;:[{&#34;url&#34;:&#34;https:\/\/a.nel.cloudflare.com\/report\/v3?s=6xbj6qtIoZ9KnqpvneqZ7JqbHW1YA41g3vG%2Bpfr8GeGsXjlUVmT3xBAtM6klNpxd9SMPyBvnsCYwnwPno%2BVLZEHNo%2FXIkPEDgLnw78FSrokBspWbC7Hakj%2FXpqNEVsbjiPzII5dbvGKZtlwoLtki&#34;}],&#34;group&#34;:&#34;cf-nel&#34;,&#34;max_age&#34;:604800}
                                     </td>
                                 </tr>
                             </tbody>
@@ -3004,7 +2994,7 @@
                                         NEL
                                     </td>
                                     <td>
-                                        {"report_to":"cf-nel","max_age":604800}
+                                        {&#34;report_to&#34;:&#34;cf-nel&#34;,&#34;max_age&#34;:604800}
                                     </td>
                                 </tr>
                             </tbody>
@@ -3024,7 +3014,7 @@
                                         CF-RAY
                                     </td>
                                     <td>
-                                        65dd1d42afc65898-POA
+                                        6789c9ff5bcb58ab-POA
                                     </td>
                                 </tr>
                             </tbody>
@@ -3044,7 +3034,7 @@
                                         alt-svc
                                     </td>
                                     <td>
-                                        h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443"; ma=86400
+                                        h3-27=&#34;:443&#34;; ma=86400, h3-28=&#34;:443&#34;; ma=86400, h3-29=&#34;:443&#34;; ma=86400, h3=&#34;:443&#34;; ma=86400
                                     </td>
                                 </tr>
                             </tbody>
@@ -3055,7 +3045,7 @@
                     <details>
                         <summary>Content</summary>
                         <p class="json-body">
-                             {"url":"http://demo.scanapi.dev/api/v1/snippets/231/","id":231,"highlight":"http://demo.scanapi.dev/api/v1/snippets/231/highlight/","owner":"guest","title":"Hello World - Ruby","code":"puts 'hello world'","linenos":false,"language":"ruby","style":"emacs"} 
+                             {&#34;url&#34;:&#34;http://demo.scanapi.dev/api/v1/snippets/630/&#34;,&#34;id&#34;:630,&#34;highlight&#34;:&#34;http://demo.scanapi.dev/api/v1/snippets/630/highlight/&#34;,&#34;owner&#34;:&#34;guest&#34;,&#34;title&#34;:&#34;Hello World - Ruby&#34;,&#34;code&#34;:&#34;puts &#39;hello world&#39;&#34;,&#34;linenos&#34;:false,&#34;language&#34;:&#34;ruby&#34;,&#34;style&#34;:&#34;emacs&#34;} 
                         </p>
                         <button class="copy__snippet">&#10063;</button>
                     </details>
@@ -3232,7 +3222,7 @@
             <label class="endpoint__title" for="chck_7">
                 <span class="endpoint__url">
                     <img data-anchor="endpoint_7" class="copy__link_anchor_url" src="https://scanapi.s3.us-east-2.amazonaws.com/assets/images/icons/link.svg">
-                    <span class="http_method">DELETE</span> /api/v1/snippets/231/
+                    <span class="http_method">DELETE</span> /api/v1/snippets/630/
                     <span class="endpoint__request_node_name">delete</span>
                 </span>
                 <span class="endpoint__titleInfo">
@@ -3246,7 +3236,7 @@
             <div class="endpoint__content">
                 <section class="endpoint__request">
                     <h3>Request</h3>
-                    <p>Full URL: <a href="http://demo.scanapi.dev/api/v1/snippets/231/"> http://demo.scanapi.dev/api/v1/snippets/231/</a></p>
+                    <p>Full URL: <a href="http://demo.scanapi.dev/api/v1/snippets/630/"> http://demo.scanapi.dev/api/v1/snippets/630/</a></p>
 
                     
                     <table>
@@ -3267,7 +3257,7 @@
                                     User-Agent
                                 </td>
                                 <td>
-                                    python-requests/2.24.0
+                                    python-requests/2.26.0
                                 </td>
                             </tr>
                             <tr>
@@ -3327,7 +3317,7 @@
 
                     <details>
                         <summary>cURL</summary>
-                        <pre>curl -X DELETE -H "User-Agent: python-requests/2.24.0" -H "Accept-Encoding: gzip, deflate" -H "Accept: */*" -H "Connection: keep-alive" -H "Content-Type: application/json" -H "Authorization: SENSITIVE_INFORMATION" -H "Content-Length: 0" -d 'None' http://demo.scanapi.dev/api/v1/snippets/231/ --compressed</pre>
+                        <pre>curl -X DELETE -H &#34;User-Agent: python-requests/2.26.0&#34; -H &#34;Accept-Encoding: gzip, deflate&#34; -H &#34;Accept: */*&#34; -H &#34;Connection: keep-alive&#34; -H &#34;Content-Type: application/json&#34; -H &#34;Authorization: SENSITIVE_INFORMATION&#34; -H &#34;Content-Length: 0&#34; -d &#39;None&#39; http://demo.scanapi.dev/api/v1/snippets/630/ --compressed</pre>
                         <button class="copy__snippet">&#10063;</button>
                     </details>
                 </section>
@@ -3349,7 +3339,7 @@
                                     response time
                                 </td>
                                 <td>
-                                    0.380578 s
+                                    0.501581 s
                                 </td>
                             </tr>
                             <tr>
@@ -3383,7 +3373,7 @@
                                         Date
                                     </td>
                                     <td>
-                                        Fri, 11 Jun 2021 19:06:02 GMT
+                                        Mon, 02 Aug 2021 19:42:23 GMT
                                     </td>
                                 </tr>
                             </tbody>
@@ -3480,20 +3470,10 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        cf-request-id
-                                    </td>
-                                    <td>
-                                        0a9e109f6a000058ab890fc000000001
-                                    </td>
-                                </tr>
-                            </tbody>
-                            <tbody>
-                                <tr>
-                                    <td>
                                         Report-To
                                     </td>
                                     <td>
-                                        {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v2?s=%2FZeB7bMAmJH%2FFrFxTq2Kl6eGvddnChJx1VpBMbzTu4tArM9fzRwlkFU4VVZSJxPqVodmwNtnsV5JwTX8oMtNfuwrHMY24QCfkJJ8C9yeT8uZWlWB%2BtrwWKy%2FTK1PQYkNFC6i9htyMdZBbw%3D%3D"}],"group":"cf-nel","max_age":604800}
+                                        {&#34;endpoints&#34;:[{&#34;url&#34;:&#34;https:\/\/a.nel.cloudflare.com\/report\/v3?s=Ve3T69YiQhIc0RRgb079r7aakcbM4m%2FSR5YGb4dQiXOIDqZcpHVuifG8zktYAlImRFiM6k%2Fv9qUAQOWVzHMwnkN2FQRf3UGYEhZNfRVXeJj1ZJQ%2B4US6ssApiJ8nHr2NJ67dzJR9c6SSb6r%2FOI8P&#34;}],&#34;group&#34;:&#34;cf-nel&#34;,&#34;max_age&#34;:604800}
                                     </td>
                                 </tr>
                             </tbody>
@@ -3503,7 +3483,7 @@
                                         NEL
                                     </td>
                                     <td>
-                                        {"report_to":"cf-nel","max_age":604800}
+                                        {&#34;report_to&#34;:&#34;cf-nel&#34;,&#34;max_age&#34;:604800}
                                     </td>
                                 </tr>
                             </tbody>
@@ -3523,7 +3503,7 @@
                                         CF-RAY
                                     </td>
                                     <td>
-                                        65dd1d457dd358ab-POA
+                                        6789ca03e849589e-POA
                                     </td>
                                 </tr>
                             </tbody>
@@ -3533,7 +3513,7 @@
                                         alt-svc
                                     </td>
                                     <td>
-                                        h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443"; ma=86400
+                                        h3-27=&#34;:443&#34;; ma=86400, h3-28=&#34;:443&#34;; ma=86400, h3-29=&#34;:443&#34;; ma=86400, h3=&#34;:443&#34;; ma=86400
                                     </td>
                                 </tr>
                             </tbody>
@@ -3544,7 +3524,7 @@
                     <details>
                         <summary>Content</summary>
                         <p class="json-body">
-                             b'' 
+                             b&#39;&#39; 
                         </p>
                         <button class="copy__snippet">&#10063;</button>
                     </details>
@@ -3616,7 +3596,7 @@
                                     User-Agent
                                 </td>
                                 <td>
-                                    python-requests/2.24.0
+                                    python-requests/2.26.0
                                 </td>
                             </tr>
                             <tr>
@@ -3668,7 +3648,7 @@
 
                     <details>
                         <summary>cURL</summary>
-                        <pre>curl -X GET -H "User-Agent: python-requests/2.24.0" -H "Accept-Encoding: gzip, deflate" -H "Accept: */*" -H "Connection: keep-alive" -H "Content-Type: application/json" -H "Authorization: SENSITIVE_INFORMATION" -d 'None' http://demo.scanapi.dev/api/v1/snippets/ --compressed</pre>
+                        <pre>curl -X GET -H &#34;User-Agent: python-requests/2.26.0&#34; -H &#34;Accept-Encoding: gzip, deflate&#34; -H &#34;Accept: */*&#34; -H &#34;Connection: keep-alive&#34; -H &#34;Content-Type: application/json&#34; -H &#34;Authorization: SENSITIVE_INFORMATION&#34; -d &#39;None&#39; http://demo.scanapi.dev/api/v1/snippets/ --compressed</pre>
                         <button class="copy__snippet">&#10063;</button>
                     </details>
                 </section>
@@ -3690,7 +3670,7 @@
                                     response time
                                 </td>
                                 <td>
-                                    0.531488 s
+                                    0.50302 s
                                 </td>
                             </tr>
                             <tr>
@@ -3724,7 +3704,7 @@
                                         Date
                                     </td>
                                     <td>
-                                        Fri, 11 Jun 2021 19:06:03 GMT
+                                        Mon, 02 Aug 2021 19:42:24 GMT
                                     </td>
                                 </tr>
                             </tbody>
@@ -3831,10 +3811,10 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        cf-request-id
+                                        Last-Modified
                                     </td>
                                     <td>
-                                        0a9e10a0e7000058998f131000000001
+                                        Mon, 02 Aug 2021 19:42:24 GMT
                                     </td>
                                 </tr>
                             </tbody>
@@ -3844,7 +3824,7 @@
                                         Report-To
                                     </td>
                                     <td>
-                                        {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v2?s=2npxMT2NrhVAZHZLQ%2B4YwJsvBkzIuxGdm2211x4oe18P1FchbvYFxsA90g9OnOOZjc3P2m3jW1ptCY25AAQVG1QjWwPvrNdtr4SBAOTxCKzHQiinnltj4F%2FDyGJhuM0GMvnf1BtGI3kBqw%3D%3D"}],"group":"cf-nel","max_age":604800}
+                                        {&#34;endpoints&#34;:[{&#34;url&#34;:&#34;https:\/\/a.nel.cloudflare.com\/report\/v3?s=mG8YTmZet1afQYttXAmiLhASUfk5m9UC0HpYGaVyh2rYskPGyCSzb4epJ868NjgWtOfGJ%2F2db3n2qxzvJ5PeDo%2F6eSkilQlPR%2FX3jl4esnmioYVMq4aBr%2BEsxft9Z3DKHNG%2B0TRUqtG1FFzAX9en&#34;}],&#34;group&#34;:&#34;cf-nel&#34;,&#34;max_age&#34;:604800}
                                     </td>
                                 </tr>
                             </tbody>
@@ -3854,7 +3834,7 @@
                                         NEL
                                     </td>
                                     <td>
-                                        {"report_to":"cf-nel","max_age":604800}
+                                        {&#34;report_to&#34;:&#34;cf-nel&#34;,&#34;max_age&#34;:604800}
                                     </td>
                                 </tr>
                             </tbody>
@@ -3874,7 +3854,7 @@
                                         CF-RAY
                                     </td>
                                     <td>
-                                        65dd1d47dd8b5899-POA
+                                        6789ca071bd15898-POA
                                     </td>
                                 </tr>
                             </tbody>
@@ -3894,7 +3874,7 @@
                                         alt-svc
                                     </td>
                                     <td>
-                                        h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443"; ma=86400
+                                        h3-27=&#34;:443&#34;; ma=86400, h3-28=&#34;:443&#34;; ma=86400, h3-29=&#34;:443&#34;; ma=86400, h3=&#34;:443&#34;; ma=86400
                                     </td>
                                 </tr>
                             </tbody>
@@ -3905,7 +3885,7 @@
                     <details>
                         <summary>Content</summary>
                         <p class="json-body">
-                             {"count":12,"next":"http://demo.scanapi.dev/api/v1/snippets/?page=2","previous":null,"results":[{"url":"http://demo.scanapi.dev/api/v1/snippets/2/","id":2,"highlight":"http://demo.scanapi.dev/api/v1/snippets/2/highlight/","owner":"admin","title":"Calculator","code":"def add(x, y):\r\n    return x + y\r\n\r\ndef subtract(x, y):\r\n    return x - y\r\n\r\ndef multiply(x, y):\r\n    return x * y\r\n\r\ndef divide(x, y):\r\n    return x / y","linenos":true,"language":"python","style":"emacs"},{"url":"http://demo.scanapi.dev/api/v1/snippets/6/","id":6,"highlight":"http://demo.scanapi.dev/api/v1/snippets/6/highlight/","owner":"guest","title":"","code":"print('hello, hello')","linenos":false,"language":"python","style":"friendly"},{"url":"http://demo.scanapi.dev/api/v1/snippets/100/","id":100,"highlight":"http://demo.scanapi.dev/api/v1/snippets/100/highlight/","owner":"my_user","title":"","code":"print('hello, hello')","linenos":false,"language":"python","style":"friendly"},{"url":"http://demo.scanapi.dev/api/v1/snippets/101/","id":101,"highlight":"http://demo.scanapi.dev/api/v1/snippets/101/highlight/","owner":"my_user","title":"Hello World","code":"print('hello world')","linenos":false,"language":"python","style":"xcode"},{"url":"http://demo.scanapi.dev/api/v1/snippets/102/","id":102,"highlight":"http://demo.scanapi.dev/api/v1/snippets/102/highlight/","owner":"my_user","title":"Hello World","code":"print('hello world')","linenos":false,"language":"python","style":"xcode"},{"url":"http://demo.scanapi.dev/api/v1/snippets/103/","id":103,"highlight":"http://demo.scanapi.dev/api/v1/snippets/103/highlight/","owner":"my_user","title":"Hello World","code":"print('hello world')","linenos":false,"language":"python","style":"xcode"},{"url":"http://demo.scanapi.dev/api/v1/snippets/104/","id":104,"highlight":"http://demo.scanapi.dev/api/v1/snippets/104/highlight/","owner":"my_user","title":"Hello World","code":"print('hello world')","linenos":false,"language":"python","style":"xcode"},{"url":"http://demo.scanapi.dev/api/v1/snippets/105/","id":105,"highlight":"http://demo.scanapi.dev/api/v1/snippets/105/highlight/","owner":"my_user","title":"Hello World","code":"print('hello world')","linenos":false,"language":"python","style":"xcode"},{"url":"http://demo.scanapi.dev/api/v1/snippets/106/","id":106,"highlight":"http://demo.scanapi.dev/api/v1/snippets/106/highlight/","owner":"my_user","title":"Hello World","code":"print('hello, patch')","linenos":false,"language":"python","style":"xcode"},{"url":"http://demo.scanapi.dev/api/v1/snippets/205/","id":205,"highlight":"http://demo.scanapi.dev/api/v1/snippets/205/highlight/","owner":"maiakovsky","title":"Hello World","code":"print('hello world')","linenos":false,"language":"python","style":"xcode"}]} 
+                             {&#34;count&#34;:15,&#34;next&#34;:&#34;http://demo.scanapi.dev/api/v1/snippets/?page=2&#34;,&#34;previous&#34;:null,&#34;results&#34;:[{&#34;url&#34;:&#34;http://demo.scanapi.dev/api/v1/snippets/2/&#34;,&#34;id&#34;:2,&#34;highlight&#34;:&#34;http://demo.scanapi.dev/api/v1/snippets/2/highlight/&#34;,&#34;owner&#34;:&#34;admin&#34;,&#34;title&#34;:&#34;Calculator&#34;,&#34;code&#34;:&#34;def add(x, y):\r\n    return x + y\r\n\r\ndef subtract(x, y):\r\n    return x - y\r\n\r\ndef multiply(x, y):\r\n    return x * y\r\n\r\ndef divide(x, y):\r\n    return x / y&#34;,&#34;linenos&#34;:true,&#34;language&#34;:&#34;python&#34;,&#34;style&#34;:&#34;emacs&#34;},{&#34;url&#34;:&#34;http://demo.scanapi.dev/api/v1/snippets/6/&#34;,&#34;id&#34;:6,&#34;highlight&#34;:&#34;http://demo.scanapi.dev/api/v1/snippets/6/highlight/&#34;,&#34;owner&#34;:&#34;guest&#34;,&#34;title&#34;:&#34;&#34;,&#34;code&#34;:&#34;print(&#39;hello, hello&#39;)&#34;,&#34;linenos&#34;:false,&#34;language&#34;:&#34;python&#34;,&#34;style&#34;:&#34;friendly&#34;},{&#34;url&#34;:&#34;http://demo.scanapi.dev/api/v1/snippets/100/&#34;,&#34;id&#34;:100,&#34;highlight&#34;:&#34;http://demo.scanapi.dev/api/v1/snippets/100/highlight/&#34;,&#34;owner&#34;:&#34;my_user&#34;,&#34;title&#34;:&#34;&#34;,&#34;code&#34;:&#34;print(&#39;hello, hello&#39;)&#34;,&#34;linenos&#34;:false,&#34;language&#34;:&#34;python&#34;,&#34;style&#34;:&#34;friendly&#34;},{&#34;url&#34;:&#34;http://demo.scanapi.dev/api/v1/snippets/101/&#34;,&#34;id&#34;:101,&#34;highlight&#34;:&#34;http://demo.scanapi.dev/api/v1/snippets/101/highlight/&#34;,&#34;owner&#34;:&#34;my_user&#34;,&#34;title&#34;:&#34;Hello World&#34;,&#34;code&#34;:&#34;print(&#39;hello world&#39;)&#34;,&#34;linenos&#34;:false,&#34;language&#34;:&#34;python&#34;,&#34;style&#34;:&#34;xcode&#34;},{&#34;url&#34;:&#34;http://demo.scanapi.dev/api/v1/snippets/102/&#34;,&#34;id&#34;:102,&#34;highlight&#34;:&#34;http://demo.scanapi.dev/api/v1/snippets/102/highlight/&#34;,&#34;owner&#34;:&#34;my_user&#34;,&#34;title&#34;:&#34;Hello World&#34;,&#34;code&#34;:&#34;print(&#39;hello world&#39;)&#34;,&#34;linenos&#34;:false,&#34;language&#34;:&#34;python&#34;,&#34;style&#34;:&#34;xcode&#34;},{&#34;url&#34;:&#34;http://demo.scanapi.dev/api/v1/snippets/103/&#34;,&#34;id&#34;:103,&#34;highlight&#34;:&#34;http://demo.scanapi.dev/api/v1/snippets/103/highlight/&#34;,&#34;owner&#34;:&#34;my_user&#34;,&#34;title&#34;:&#34;Hello World&#34;,&#34;code&#34;:&#34;print(&#39;hello world&#39;)&#34;,&#34;linenos&#34;:false,&#34;language&#34;:&#34;python&#34;,&#34;style&#34;:&#34;xcode&#34;},{&#34;url&#34;:&#34;http://demo.scanapi.dev/api/v1/snippets/104/&#34;,&#34;id&#34;:104,&#34;highlight&#34;:&#34;http://demo.scanapi.dev/api/v1/snippets/104/highlight/&#34;,&#34;owner&#34;:&#34;my_user&#34;,&#34;title&#34;:&#34;Hello World&#34;,&#34;code&#34;:&#34;print(&#39;hello world&#39;)&#34;,&#34;linenos&#34;:false,&#34;language&#34;:&#34;python&#34;,&#34;style&#34;:&#34;xcode&#34;},{&#34;url&#34;:&#34;http://demo.scanapi.dev/api/v1/snippets/105/&#34;,&#34;id&#34;:105,&#34;highlight&#34;:&#34;http://demo.scanapi.dev/api/v1/snippets/105/highlight/&#34;,&#34;owner&#34;:&#34;my_user&#34;,&#34;title&#34;:&#34;Hello World&#34;,&#34;code&#34;:&#34;print(&#39;hello world&#39;)&#34;,&#34;linenos&#34;:false,&#34;language&#34;:&#34;python&#34;,&#34;style&#34;:&#34;xcode&#34;},{&#34;url&#34;:&#34;http://demo.scanapi.dev/api/v1/snippets/106/&#34;,&#34;id&#34;:106,&#34;highlight&#34;:&#34;http://demo.scanapi.dev/api/v1/snippets/106/highlight/&#34;,&#34;owner&#34;:&#34;my_user&#34;,&#34;title&#34;:&#34;Hello World&#34;,&#34;code&#34;:&#34;print(&#39;hello, patch&#39;)&#34;,&#34;linenos&#34;:false,&#34;language&#34;:&#34;python&#34;,&#34;style&#34;:&#34;xcode&#34;},{&#34;url&#34;:&#34;http://demo.scanapi.dev/api/v1/snippets/205/&#34;,&#34;id&#34;:205,&#34;highlight&#34;:&#34;http://demo.scanapi.dev/api/v1/snippets/205/highlight/&#34;,&#34;owner&#34;:&#34;maiakovsky&#34;,&#34;title&#34;:&#34;Hello World&#34;,&#34;code&#34;:&#34;print(&#39;hello world&#39;)&#34;,&#34;linenos&#34;:false,&#34;language&#34;:&#34;python&#34;,&#34;style&#34;:&#34;xcode&#34;}]} 
                         </p>
                         <button class="copy__snippet">&#10063;</button>
                     </details>
@@ -3977,7 +3957,7 @@
                                     User-Agent
                                 </td>
                                 <td>
-                                    python-requests/2.24.0
+                                    python-requests/2.26.0
                                 </td>
                             </tr>
                             <tr>
@@ -4021,7 +4001,7 @@
 
                     <details>
                         <summary>cURL</summary>
-                        <pre>curl -X GET -H "User-Agent: python-requests/2.24.0" -H "Accept-Encoding: gzip, deflate" -H "Accept: */*" -H "Connection: keep-alive" -H "Content-Type: application/json" -d 'None' http://demo.scanapi.dev/api/v1/users/ --compressed</pre>
+                        <pre>curl -X GET -H &#34;User-Agent: python-requests/2.26.0&#34; -H &#34;Accept-Encoding: gzip, deflate&#34; -H &#34;Accept: */*&#34; -H &#34;Connection: keep-alive&#34; -H &#34;Content-Type: application/json&#34; -d &#39;None&#39; http://demo.scanapi.dev/api/v1/users/ --compressed</pre>
                         <button class="copy__snippet">&#10063;</button>
                     </details>
                 </section>
@@ -4043,7 +4023,7 @@
                                     response time
                                 </td>
                                 <td>
-                                    0.426912 s
+                                    0.407432 s
                                 </td>
                             </tr>
                             <tr>
@@ -4077,7 +4057,7 @@
                                         Date
                                     </td>
                                     <td>
-                                        Fri, 11 Jun 2021 19:06:03 GMT
+                                        Mon, 02 Aug 2021 19:42:24 GMT
                                     </td>
                                 </tr>
                             </tbody>
@@ -4184,10 +4164,10 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        cf-request-id
+                                        Last-Modified
                                     </td>
                                     <td>
-                                        0a9e10a303000058aa1f069000000001
+                                        Mon, 02 Aug 2021 19:42:24 GMT
                                     </td>
                                 </tr>
                             </tbody>
@@ -4197,7 +4177,7 @@
                                         Report-To
                                     </td>
                                     <td>
-                                        {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v2?s=ZapWsO7bGvCUQcQWs541eBDs77Y3ggEVMtFC7OgnK1vjIHJqV4Juc4arajt%2Bb8%2BQ3r9z2JUrjv%2FxSD%2F5BygsTuvSd1Z8g8suU5560WbuiOd5kp9wunUTr06Ugv6swx9v3P8y6UTRgqHSzg%3D%3D"}],"group":"cf-nel","max_age":604800}
+                                        {&#34;endpoints&#34;:[{&#34;url&#34;:&#34;https:\/\/a.nel.cloudflare.com\/report\/v3?s=mxfFCe5YvYzFRZ9Zm7DIvLaqJM9a5KKvuqP25rHvDXVvQ5Oy%2BK6SKHu9C9cBYnOt8IZ7H10eJaY3FoM8qoFWoJRjyrbbkh%2BrEryEIOO6eJjXMcdqY0goKGWeDSEoaAR14EZnrM4JkEtJe1YaOit%2B&#34;}],&#34;group&#34;:&#34;cf-nel&#34;,&#34;max_age&#34;:604800}
                                     </td>
                                 </tr>
                             </tbody>
@@ -4207,7 +4187,7 @@
                                         NEL
                                     </td>
                                     <td>
-                                        {"report_to":"cf-nel","max_age":604800}
+                                        {&#34;report_to&#34;:&#34;cf-nel&#34;,&#34;max_age&#34;:604800}
                                     </td>
                                 </tr>
                             </tbody>
@@ -4227,7 +4207,7 @@
                                         CF-RAY
                                     </td>
                                     <td>
-                                        65dd1d4b3af258aa-POA
+                                        6789ca0a48bb58aa-POA
                                     </td>
                                 </tr>
                             </tbody>
@@ -4247,7 +4227,7 @@
                                         alt-svc
                                     </td>
                                     <td>
-                                        h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443"; ma=86400
+                                        h3-27=&#34;:443&#34;; ma=86400, h3-28=&#34;:443&#34;; ma=86400, h3-29=&#34;:443&#34;; ma=86400, h3=&#34;:443&#34;; ma=86400
                                     </td>
                                 </tr>
                             </tbody>
@@ -4258,7 +4238,7 @@
                     <details>
                         <summary>Content</summary>
                         <p class="json-body">
-                             {"count":5,"next":null,"previous":null,"results":[{"url":"http://demo.scanapi.dev/api/v1/users/2/","id":2,"username":"guest","snippets":["http://demo.scanapi.dev/api/v1/snippets/6/"]},{"url":"http://demo.scanapi.dev/api/v1/users/5/","id":5,"username":"pradhvan","snippets":[]},{"url":"http://demo.scanapi.dev/api/v1/users/8/","id":8,"username":"my_user","snippets":["http://demo.scanapi.dev/api/v1/snippets/100/","http://demo.scanapi.dev/api/v1/snippets/101/","http://demo.scanapi.dev/api/v1/snippets/102/","http://demo.scanapi.dev/api/v1/snippets/103/","http://demo.scanapi.dev/api/v1/snippets/104/","http://demo.scanapi.dev/api/v1/snippets/105/","http://demo.scanapi.dev/api/v1/snippets/106/"]},{"url":"http://demo.scanapi.dev/api/v1/users/1/","id":1,"username":"admin","snippets":["http://demo.scanapi.dev/api/v1/snippets/2/"]},{"url":"http://demo.scanapi.dev/api/v1/users/9/","id":9,"username":"maiakovsky","snippets":["http://demo.scanapi.dev/api/v1/snippets/205/","http://demo.scanapi.dev/api/v1/snippets/206/","http://demo.scanapi.dev/api/v1/snippets/207/"]}]} 
+                             {&#34;count&#34;:7,&#34;next&#34;:null,&#34;previous&#34;:null,&#34;results&#34;:[{&#34;url&#34;:&#34;http://demo.scanapi.dev/api/v1/users/5/&#34;,&#34;id&#34;:5,&#34;username&#34;:&#34;pradhvan&#34;,&#34;snippets&#34;:[]},{&#34;url&#34;:&#34;http://demo.scanapi.dev/api/v1/users/9/&#34;,&#34;id&#34;:9,&#34;username&#34;:&#34;maiakovsky&#34;,&#34;snippets&#34;:[&#34;http://demo.scanapi.dev/api/v1/snippets/205/&#34;,&#34;http://demo.scanapi.dev/api/v1/snippets/206/&#34;,&#34;http://demo.scanapi.dev/api/v1/snippets/207/&#34;]},{&#34;url&#34;:&#34;http://demo.scanapi.dev/api/v1/users/8/&#34;,&#34;id&#34;:8,&#34;username&#34;:&#34;my_user&#34;,&#34;snippets&#34;:[&#34;http://demo.scanapi.dev/api/v1/snippets/100/&#34;,&#34;http://demo.scanapi.dev/api/v1/snippets/101/&#34;,&#34;http://demo.scanapi.dev/api/v1/snippets/102/&#34;,&#34;http://demo.scanapi.dev/api/v1/snippets/103/&#34;,&#34;http://demo.scanapi.dev/api/v1/snippets/104/&#34;,&#34;http://demo.scanapi.dev/api/v1/snippets/105/&#34;,&#34;http://demo.scanapi.dev/api/v1/snippets/106/&#34;]},{&#34;url&#34;:&#34;http://demo.scanapi.dev/api/v1/users/1/&#34;,&#34;id&#34;:1,&#34;username&#34;:&#34;admin&#34;,&#34;snippets&#34;:[&#34;http://demo.scanapi.dev/api/v1/snippets/2/&#34;]},{&#34;url&#34;:&#34;http://demo.scanapi.dev/api/v1/users/11/&#34;,&#34;id&#34;:11,&#34;username&#34;:&#34;vitorcosta&#34;,&#34;snippets&#34;:[]},{&#34;url&#34;:&#34;http://demo.scanapi.dev/api/v1/users/10/&#34;,&#34;id&#34;:10,&#34;username&#34;:&#34;rich&#34;,&#34;snippets&#34;:[]},{&#34;url&#34;:&#34;http://demo.scanapi.dev/api/v1/users/2/&#34;,&#34;id&#34;:2,&#34;username&#34;:&#34;guest&#34;,&#34;snippets&#34;:[&#34;http://demo.scanapi.dev/api/v1/snippets/6/&#34;,&#34;http://demo.scanapi.dev/api/v1/snippets/319/&#34;,&#34;http://demo.scanapi.dev/api/v1/snippets/410/&#34;,&#34;http://demo.scanapi.dev/api/v1/snippets/411/&#34;]}]} 
                         </p>
                         <button class="copy__snippet">&#10063;</button>
                     </details>
@@ -4309,7 +4289,7 @@
             <label class="endpoint__title" for="chck_10">
                 <span class="endpoint__url">
                     <img data-anchor="endpoint_10" class="copy__link_anchor_url" src="https://scanapi.s3.us-east-2.amazonaws.com/assets/images/icons/link.svg">
-                    <span class="http_method">GET</span> /api/v1/users/2/
+                    <span class="http_method">GET</span> /api/v1/users/5/
                     <span class="endpoint__request_node_name">details</span>
                 </span>
                 <span class="endpoint__titleInfo">
@@ -4323,7 +4303,7 @@
             <div class="endpoint__content">
                 <section class="endpoint__request">
                     <h3>Request</h3>
-                    <p>Full URL: <a href="http://demo.scanapi.dev/api/v1/users/2/"> http://demo.scanapi.dev/api/v1/users/2/</a></p>
+                    <p>Full URL: <a href="http://demo.scanapi.dev/api/v1/users/5/"> http://demo.scanapi.dev/api/v1/users/5/</a></p>
 
                     
                     <table>
@@ -4344,7 +4324,7 @@
                                     User-Agent
                                 </td>
                                 <td>
-                                    python-requests/2.24.0
+                                    python-requests/2.26.0
                                 </td>
                             </tr>
                             <tr>
@@ -4388,7 +4368,7 @@
 
                     <details>
                         <summary>cURL</summary>
-                        <pre>curl -X GET -H "User-Agent: python-requests/2.24.0" -H "Accept-Encoding: gzip, deflate" -H "Accept: */*" -H "Connection: keep-alive" -H "Content-Type: application/json" -d 'None' http://demo.scanapi.dev/api/v1/users/2/ --compressed</pre>
+                        <pre>curl -X GET -H &#34;User-Agent: python-requests/2.26.0&#34; -H &#34;Accept-Encoding: gzip, deflate&#34; -H &#34;Accept: */*&#34; -H &#34;Connection: keep-alive&#34; -H &#34;Content-Type: application/json&#34; -d &#39;None&#39; http://demo.scanapi.dev/api/v1/users/5/ --compressed</pre>
                         <button class="copy__snippet">&#10063;</button>
                     </details>
                 </section>
@@ -4410,7 +4390,7 @@
                                     response time
                                 </td>
                                 <td>
-                                    0.380849 s
+                                    0.394388 s
                                 </td>
                             </tr>
                             <tr>
@@ -4444,7 +4424,7 @@
                                         Date
                                     </td>
                                     <td>
-                                        Fri, 11 Jun 2021 19:06:04 GMT
+                                        Mon, 02 Aug 2021 19:42:25 GMT
                                     </td>
                                 </tr>
                             </tbody>
@@ -4551,10 +4531,10 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        cf-request-id
+                                        Last-Modified
                                     </td>
                                     <td>
-                                        0a9e10a4b8000058ab5c03f000000001
+                                        Mon, 02 Aug 2021 19:42:25 GMT
                                     </td>
                                 </tr>
                             </tbody>
@@ -4564,7 +4544,7 @@
                                         Report-To
                                     </td>
                                     <td>
-                                        {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v2?s=EXkeCl68Q%2BWh5mckSnyjiepFtVLA7B3nwY6UaE0bkVK4fRIWgALMCUq9tLtjWUQLZ2QS33%2Fyqa5B4wuv%2BqRe0%2FFnMB%2BxPVb1hVQ6yv4rflYZNEQ4mMP9AFs4ZaSBtvtm6NO8xqTguShW5A%3D%3D"}],"group":"cf-nel","max_age":604800}
+                                        {&#34;endpoints&#34;:[{&#34;url&#34;:&#34;https:\/\/a.nel.cloudflare.com\/report\/v3?s=ujAmcBO5bX1g0UkDJz6JJFAQ6q4QJXqAq5eONG6hxgpIydlQhdMhFpzH40t3bCq1SkKpHmeVsOwb7oO9KQMvzm7fA%2Fpaza%2BfeyFOyg5IoteizlatMLFGh6LDWlrh4rYJl8KVC5OTlIaG4bopXwaI&#34;}],&#34;group&#34;:&#34;cf-nel&#34;,&#34;max_age&#34;:604800}
                                     </td>
                                 </tr>
                             </tbody>
@@ -4574,7 +4554,7 @@
                                         NEL
                                     </td>
                                     <td>
-                                        {"report_to":"cf-nel","max_age":604800}
+                                        {&#34;report_to&#34;:&#34;cf-nel&#34;,&#34;max_age&#34;:604800}
                                     </td>
                                 </tr>
                             </tbody>
@@ -4594,7 +4574,7 @@
                                         CF-RAY
                                     </td>
                                     <td>
-                                        65dd1d4dfc0658ab-POA
+                                        6789ca0cea3258aa-POA
                                     </td>
                                 </tr>
                             </tbody>
@@ -4614,7 +4594,7 @@
                                         alt-svc
                                     </td>
                                     <td>
-                                        h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443"; ma=86400
+                                        h3-27=&#34;:443&#34;; ma=86400, h3-28=&#34;:443&#34;; ma=86400, h3-29=&#34;:443&#34;; ma=86400, h3=&#34;:443&#34;; ma=86400
                                     </td>
                                 </tr>
                             </tbody>
@@ -4625,7 +4605,7 @@
                     <details>
                         <summary>Content</summary>
                         <p class="json-body">
-                             {"url":"http://demo.scanapi.dev/api/v1/users/2/","id":2,"username":"guest","snippets":["http://demo.scanapi.dev/api/v1/snippets/6/"]} 
+                             {&#34;url&#34;:&#34;http://demo.scanapi.dev/api/v1/users/5/&#34;,&#34;id&#34;:5,&#34;username&#34;:&#34;pradhvan&#34;,&#34;snippets&#34;:[]} 
                         </p>
                         <button class="copy__snippet">&#10063;</button>
                     </details>
@@ -4676,12 +4656,12 @@
                 <span><strong>PASSED:</strong> 55</span>
                 <span><strong>FAILURES:</strong> 0</span>
                 <span><strong>ERRORS:</strong> 0</span>
-                <span><strong>Total Time:</strong> 0:00:05.701572</span>
+                <span><strong>Total Time:</strong> 0:00:05.680046</span>
             </div>
         </div>
 
         <div class="scanapi_version">
-            <span>Generated by ScanAPI 2.4.0</span>
+            <span>Generated by ScanAPI 2.5.0</span>
         </div>
 
         <a class="github" href="https://github.com/scanapi/scanapi"><img class="github__svg" src="https://scanapi.s3.us-east-2.amazonaws.com/assets/images/github/github-logo.svg" /></a>

--- a/demo-api/scanapi.yaml
+++ b/demo-api/scanapi.yaml
@@ -20,7 +20,7 @@ endpoints:
         tests:
           - !include tests/status_code_is_200.yaml
           - !include tests/key_in_content.yaml
-          - !include tests/response_time.yaml
+          - !include tests/response_time_2_seconds.yaml
     endpoints:
       - !include snippets.yaml
       - !include users.yaml

--- a/demo-api/snippets.yaml
+++ b/demo-api/snippets.yaml
@@ -14,7 +14,7 @@ requests:
     snippet_id: ${{response.json()["id"]}}
   tests:
     - !include tests/status_code_is_201.yaml
-    - !include tests/response_time.yaml
+    - !include tests/response_time_2_seconds.yaml
     - !include tests/url_in_content.yaml
     - !include tests/id_in_content.yaml
     - !include tests/highlight_in_content.yaml

--- a/demo-api/tests/response_time_2_seconds.yaml
+++ b/demo-api/tests/response_time_2_seconds.yaml
@@ -1,0 +1,2 @@
+name: response_time_is_under_two_seconds
+assert: ${{ response.elapsed.total_seconds() < 2 }}


### PR DESCRIPTION
Increase max time for some response time tests. Sometimes the API does not responds under a second and it makes the CI of the scanapi main repo fails

Closes #28 